### PR TITLE
change the .gitmodules from ssh to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libs/cauldron"]
 	path = libs/cauldron
-	url = git@github.com:GPUOpen-LibrariesAndSDKs/Cauldron.git
+	url = https://github.com/GPUOpen-LibrariesAndSDKs/Cauldron.git


### PR DESCRIPTION
Use the url like 

> `git@github.com:GPUOpen-LibrariesAndSDKs/Cauldron.git`

will some get the error when exec `git submodule update --init --recursive` like this

> `Please make sure you have the correct access rights                                                                                                and the repository exists.                                                                                                                         fatal: clone of 'git@github.com:GPUOpen-LibrariesAndSDKs/Cauldron.git' into submodule path`


so change the protocol from ssh to https . it will clone well.

Signed-off-by: juteman <hhjuteman@gmail.com>